### PR TITLE
Email regex should support + char for valid email addresses like moomerman+test@example.com

### DIFF
--- a/lib/ruby_regex.rb
+++ b/lib/ruby_regex.rb
@@ -48,7 +48,7 @@ module RubyRegex
   # Email
   # From the email regex research: http://fightingforalostcause.net/misc/2006/compare-email-regex.php
   # Authors: James Watts and Francisco Jose Martin Moreno
-  Email = /\A([\w\!\#\z\%\&\'\*\+\-\/\=\?\\A\`{\|\}\~]+\.)*[\w-]+@((((([a-z0-9]{1}[a-z0-9\-]{0,62}[a-z0-9]{1})|[a-z])\.)+[a-z]{2,6})|(\d{1,3}\.){3}\d{1,3}(\:\d{1,5})?)\z/i
+  Email = /\A([\w\!\#\z\%\&\'\*\+\-\/\=\?\\A\`{\|\}\~]+\.)*[\w\+-]+@((((([a-z0-9]{1}[a-z0-9\-]{0,62}[a-z0-9]{1})|[a-z])\.)+[a-z]{2,6})|(\d{1,3}\.){3}\d{1,3}(\:\d{1,5})?)\z/i
 
   # UUID
   # Validates a UUID as defined: http://en.wikipedia.org/wiki/Universally_unique_identifier

--- a/test/fixtures/emails.yml
+++ b/test/fixtures/emails.yml
@@ -14,6 +14,7 @@ valid:
   - "a@singleLetterLocal.org"
   - "singleLetterDomain@x.org"
   - "foor@bar.newTLD"
+  - "with+plus@example.com"
 
 
 invalid:


### PR DESCRIPTION
added + (plus) to the valid characters in email to support valid email addresses like moomerman+test@example.com, includes test
